### PR TITLE
Modmail Completion

### DIFF
--- a/commands/Moderation.py
+++ b/commands/Moderation.py
@@ -19,7 +19,6 @@ class Moderation(commands.Cog):
         warnlog_channel_id = self.gpdb.get_pref("warnlog_channel", message.guild.id)
         if message.channel.id in [modlog_channel_id, warnlog_channel_id]:
             match = re.search(r'Case #(\d+)', message.content)
-
             if match:
                 deleted_case_no = int(match.group(1))
                 guild_infractions = self.gpdb.db['infractions'].find_one(

--- a/commands/Moderation.py
+++ b/commands/Moderation.py
@@ -115,7 +115,7 @@ class Moderation(commands.Cog):
                 text = ('\n\n'.join(history))[:1900]
                 await interaction.send(f"{user}'s Moderation History:\n```{text}```", ephemeral=False)
         else:
-            await interaction.send("Please set up your moglog and warnlog through /set_preferences first!")
+            await interaction.send("Please set up your modlog and warnlog through /set_preferences first!")
 
     @discord.slash_command(description="Warn a user (for mods)")
     async def warn(self, interaction: discord.Interaction,

--- a/commands/Moderation.py
+++ b/commands/Moderation.py
@@ -10,6 +10,8 @@ class Moderation(commands.Cog):
         self.gpdb = functions.preferences.gpdb
     @commands.Cog.listener()
     async def on_message_delete(self, message):
+        if not message.guild:
+            return
         modlog_channel_id = functions.preferences.gpdb.get_pref("modlog_channel", message.guild.id)
         warnlog_channel_id = functions.preferences.gpdb.get_pref("warnlog_channel", message.guild.id)
         if message.channel.id in [modlog_channel_id, warnlog_channel_id]:

--- a/commands/Modmail.py
+++ b/commands/Modmail.py
@@ -1,91 +1,126 @@
 import nextcord as discord
+from nextcord.ext import commands
 import functions
+import asyncio
 
 class Modmail(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.gpdb = functions.preferences.gpdb
+    
     @commands.Cog.listener()
-    def on_message(self, message):
+    async def on_message(self, message):
+        if message.author == self.bot.user:
+            return
+        if not isinstance(message.channel, discord.DMChannel) and not functions.preferences.gpdb.get_pref("modmail_channel", message.guild.id):
+            return
         if not message.guild:
-            mutual_guilds = [guild for guild in bot.guilds if message.author in guild.members]
+            mutual_guilds = [guild for guild in self.bot.guilds if message.author in guild.members]
             if len(mutual_guilds) == 1:
                 guild = mutual_guilds[0]
             else:
                 guild_list = "\n".join([f"{i+1}. {guild.name}" for i, guild in enumerate(mutual_guilds)])
-                embed = discord.Embed(title="Choose Server", description=f"You and the bot are both in these servers, which one do you want to send it to:\n{guild_list}", colour=discord.Colour.green())
+                embed = discord.Embed(title="Choose Server", description=f"You and the bot are both in these servers, which one do you want to send it to:\n{guild_list}", colour=discord.Colour.yellow())
                 embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
                 msg = await message.channel.send(embed=embed)
                 for i in range(len(mutual_guilds)):
                     await msg.add_reaction(f"{i+1}️⃣")
                 def check(reaction, user):
                     return user == message.author and str(reaction.emoji) in [f"{i+1}️⃣" for i in range(len(mutual_guilds))]
-                reaction, user = await bot.wait_for('reaction_add', check=check)
+                reaction, user = await self.bot.wait_for('reaction_add', check=check)
                 guild = mutual_guilds[int(str(reaction)[0])-1]
-            category = discord.utils.get(guild.categories, name='COMMS')
-            channel = discord.utils.get(category.channels, topic=str(message.author.id))
-            if not channel:
-                channel = await guild.create_text_channel(str(message.author).replace("#", "-"),
-                                                        category=category,
-                                                        topic=str(message.author.id))
-            embed = discord.Embed(title="Message Received", description=f"This message will be sent to the mods of the {guild.name} server. Are you sure you want to send this?",
-                                colour=discord.Colour.green())
+
+            forum_channel = discord.utils.get(guild.channels, name='modmail', type=discord.ChannelType.forum)
+            if forum_channel is None:
+                forum_channel = await guild.create_forum_channel(name='modmail', topic="Modmail for DMs")
+            thread = discord.utils.get(forum_channel.threads, name=f"{message.author}")
+            if thread is None:
+                thread = await forum_channel.create_thread(name=f"{message.author}", auto_archive_duration=60, content="New DM received.")
+
+            if functions.preferences.gpdb.get_pref("modmail_channel", guild.id): embed = discord.Embed(title="Message Received", description=f"This message will be sent to the mods of the {guild.name} server. Are you sure you want to send this?\nClick on the :white_check_mark: to confirm, and :x: to terminate this conversation", colour=discord.Colour.yellow())
+            else:
+                embed = discord.Embed(title="Message Declined", description=f"{guild.name} has not yet setup modmail. Use /set_preferences to set it up", colour=discord.Colour.red())
+                embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
+                await message.author.send(embed=embed)
+                return
             embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
-            msg = await channel.send(embed=embed)
+            msg = await message.author.send(embed=embed)
             await msg.add_reaction("✅")
+            await msg.add_reaction("❌")
             def check(reaction, user):
-                return user == message.author and str(reaction.emoji) == '✅'
-            reaction, user = await bot.wait_for('reaction_add', check=check)
-            embed = discord.Embed(title="Message Received", description=message.clean_content,
-                                colour=discord.Colour.green())
-            embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
-            await channel.send(embed=embed)
-            for attachment in message.attachments:
-                await channel.send(file=await attachment.to_file())
-            await message.add_reaction("✅")
+                return user == message.author and str(reaction.emoji) in ['✅', '❌']
+            reaction, user = await self.bot.wait_for('reaction_add', check=check)
+            if str(reaction.emoji) == '✅':
+                embed = discord.Embed(title="Message Sent", description=f"Your message has been sent to the mods of the {guild.name} server.", colour=discord.Colour.green())
+                embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
+                await msg.edit(embed=embed)
+                embed = discord.Embed(title="Message Received", description=message.clean_content,
+                                    colour=discord.Colour.green())
+                embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
+                await thread.send(embed=embed)
+                for attachment in message.attachments:
+                    await thread.send(file=await attachment.to_file())
+                await message.add_reaction("✅")
+            else:
+                embed = discord.Embed(title="Conversation Terminated", description=f"The conversation has been terminated.", colour=discord.Colour.red())
+                await msg.edit(embed=embed)
+                await asyncio.sleep(5)
+                await msg.delete()
 
-        if message.guild.id == 576460042774118420 and message.channel.category:  # Sending modmails
-            if message.channel.category.name.lower() == "comms" and not message.author.bot:
-                if int(message.channel.topic) == message.author.id:
-                    return
-                else:
-                    member = message.guild.get_member(int(message.channel.topic))
-                    if message.content == ".sclose":
-                        embed = discord.Embed(title="DM Channel Silently Closed",
-                                            description=f"DM Channel with {member} has been closed by the moderators of r/IGCSE, without notifying the user.", colour=discord.Colour.green())
-                        embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
-                        await message.channel.delete()
-                        await bot.get_channel(895961641219407923).send(embed=embed)
-                        return
-                    channel = await member.create_dm()
-                    if message.content == ".close":
-                        embed = discord.Embed(title="DM Channel Closed",
-                                            description=f"DM Channel with {member} has been closed by the moderators of r/IGCSE.", colour=discord.Colour.green())
-                        embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
-                        await channel.send(embed=embed)
-                        await message.channel.delete()
-                        await bot.get_channel(895961641219407923).send(embed=embed)
-                        return
-                    embed = discord.Embed(title="Message from r/IGCSE Moderators",
-                                            description=message.clean_content, colour=discord.Colour.green())
+        else:
+            modlog_channel_id = functions.preferences.gpdb.get_pref("modmail_channel", message.guild.id)
+            if str(message.channel.parent) == "modmail":
+                username, discriminator = message.channel.name.split('#')
+                user = discord.utils.find(lambda u: u.name == username and u.discriminator == discriminator, self.bot.users)
+                if user:
+                    member = await message.guild.fetch_member(user.id)
+                if message.content == ".sclose":
+                    embed = discord.Embed(title="DM Channel Silently Closed",
+                                        description=f"DM Channel with {member} has been closed by the moderators of r/IGCSE, without notifying the user.", colour=discord.Colour.green())
                     embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
+                    await message.channel.delete()
+                    await self.bot.get_channel(modlog_channel_id).send(embed=embed)
+                    return
+                channel = await member.create_dm()  
+                if message.content == ".close":
+                    embed = discord.Embed(title="DM Channel Closed",
+                                        description=f"DM Channel with {member} has been closed by the moderators of r/IGCSE.", colour=discord.Colour.green())
+                    embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
+                    await channel.send(embed=embed)
+                    await message.channel.delete()
+                    await self.bot.get_channel(modlog_channel_id).send(embed=embed)
+                    return
+                embed = discord.Embed(title=f"Message from {message.guild.name} Moderators",
+                                        description=message.clean_content, colour=discord.Colour.green())
+                embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
 
-                    try:
-                        await channel.send(embed=embed)
-                        for attachment in message.attachments:
-                            await channel.send(file=await attachment.to_file())
-                        await message.channel.send(embed=embed)
-                    except:
-                        perms = message.channel.overwrites_for(member)
-                        perms.send_messages, perms.read_messages, perms.view_channel, perms.read_message_history, perms.attach_files = True, True, True, True, True
-                        await message.channel.set_permissions(member, overwrite=perms)
-                        await message.channel.send(f"{member.mention}")
-                        return
+                try:
+                    await channel.send(embed=embed)
+                    for attachment in message.attachments:
+                        await channel.send(file=await attachment.to_file())
+                    await message.channel.send(embed=embed)
+                except:
+                    perms = message.channel.overwrites_for(member)
+                    perms.send_messages, perms.read_messages, perms.view_channel, perms.read_message_history, perms.attach_files = True, True, True, True, True
+                    await message.channel.set_permissions(member, overwrite=perms)
+                    await message.channel.send(f"{member.mention}")
+                    return
 
-                    await message.delete()
-    @discord.slash_command(description="Create a modmail channel for a user")
+                await message.delete()
+    @discord.slash_command(description="Create a modmail thread for a user")
     async def create_modmail(self, interaction: discord.Interaction,
-                            user: discord.Member = discord.SlashOption(name="user", description="User to create a modmail channel for", required=True)):
-        category = discord.utils.get(interaction.guild.categories, name='COMMS')
-        channel = discord.utils.get(category.channels, topic=str(user.id))
-        if not channel:
-            channel = await interaction.guild.create_text_channel(str(user).replace("#", "-"),
-                                                                category=category, topic=str(user.id))
-        await interaction.response.send_message(f"DM Channel has been created at {channel.mention}")
+                            user: discord.Member = discord.SlashOption(name="user", description="User to create a modmail thread for", required=True)):
+        forum_channel = discord.utils.get(interaction.guild.channels, name='modmail', type=discord.ChannelType.forum)
+        if forum_channel is None:
+            forum_channel = await guild.create_forum_channel(name='modmail', topic="Modmail for DMs")
+        thread = discord.utils.get(forum_channel.threads, name=f"{user}")
+        if thread is None:
+            thread = await forum_channel.create_thread(name=f"{user}", auto_archive_duration=60, content="New DM received/created.")
+            await interaction.response.send_message(f"DM Thread has been created at {thread.mention}")
+        else:
+            await thread.send(content="New DM created.")
+            await interaction.response.send_message(f"DM Thread already exists at {thread.mention}")
+
+
+def setup(bot):
+    bot.add_cog(Modmail(bot))

--- a/commands/Modmail.py
+++ b/commands/Modmail.py
@@ -1,0 +1,91 @@
+import nextcord as discord
+import functions
+
+class Modmail(commands.Cog):
+    @commands.Cog.listener()
+    def on_message(self, message):
+        if not message.guild:
+            mutual_guilds = [guild for guild in bot.guilds if message.author in guild.members]
+            if len(mutual_guilds) == 1:
+                guild = mutual_guilds[0]
+            else:
+                guild_list = "\n".join([f"{i+1}. {guild.name}" for i, guild in enumerate(mutual_guilds)])
+                embed = discord.Embed(title="Choose Server", description=f"You and the bot are both in these servers, which one do you want to send it to:\n{guild_list}", colour=discord.Colour.green())
+                embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
+                msg = await message.channel.send(embed=embed)
+                for i in range(len(mutual_guilds)):
+                    await msg.add_reaction(f"{i+1}️⃣")
+                def check(reaction, user):
+                    return user == message.author and str(reaction.emoji) in [f"{i+1}️⃣" for i in range(len(mutual_guilds))]
+                reaction, user = await bot.wait_for('reaction_add', check=check)
+                guild = mutual_guilds[int(str(reaction)[0])-1]
+            category = discord.utils.get(guild.categories, name='COMMS')
+            channel = discord.utils.get(category.channels, topic=str(message.author.id))
+            if not channel:
+                channel = await guild.create_text_channel(str(message.author).replace("#", "-"),
+                                                        category=category,
+                                                        topic=str(message.author.id))
+            embed = discord.Embed(title="Message Received", description=f"This message will be sent to the mods of the {guild.name} server. Are you sure you want to send this?",
+                                colour=discord.Colour.green())
+            embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
+            msg = await channel.send(embed=embed)
+            await msg.add_reaction("✅")
+            def check(reaction, user):
+                return user == message.author and str(reaction.emoji) == '✅'
+            reaction, user = await bot.wait_for('reaction_add', check=check)
+            embed = discord.Embed(title="Message Received", description=message.clean_content,
+                                colour=discord.Colour.green())
+            embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
+            await channel.send(embed=embed)
+            for attachment in message.attachments:
+                await channel.send(file=await attachment.to_file())
+            await message.add_reaction("✅")
+
+        if message.guild.id == 576460042774118420 and message.channel.category:  # Sending modmails
+            if message.channel.category.name.lower() == "comms" and not message.author.bot:
+                if int(message.channel.topic) == message.author.id:
+                    return
+                else:
+                    member = message.guild.get_member(int(message.channel.topic))
+                    if message.content == ".sclose":
+                        embed = discord.Embed(title="DM Channel Silently Closed",
+                                            description=f"DM Channel with {member} has been closed by the moderators of r/IGCSE, without notifying the user.", colour=discord.Colour.green())
+                        embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
+                        await message.channel.delete()
+                        await bot.get_channel(895961641219407923).send(embed=embed)
+                        return
+                    channel = await member.create_dm()
+                    if message.content == ".close":
+                        embed = discord.Embed(title="DM Channel Closed",
+                                            description=f"DM Channel with {member} has been closed by the moderators of r/IGCSE.", colour=discord.Colour.green())
+                        embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
+                        await channel.send(embed=embed)
+                        await message.channel.delete()
+                        await bot.get_channel(895961641219407923).send(embed=embed)
+                        return
+                    embed = discord.Embed(title="Message from r/IGCSE Moderators",
+                                            description=message.clean_content, colour=discord.Colour.green())
+                    embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
+
+                    try:
+                        await channel.send(embed=embed)
+                        for attachment in message.attachments:
+                            await channel.send(file=await attachment.to_file())
+                        await message.channel.send(embed=embed)
+                    except:
+                        perms = message.channel.overwrites_for(member)
+                        perms.send_messages, perms.read_messages, perms.view_channel, perms.read_message_history, perms.attach_files = True, True, True, True, True
+                        await message.channel.set_permissions(member, overwrite=perms)
+                        await message.channel.send(f"{member.mention}")
+                        return
+
+                    await message.delete()
+    @discord.slash_command(description="Create a modmail channel for a user")
+    async def create_modmail(self, interaction: discord.Interaction,
+                            user: discord.Member = discord.SlashOption(name="user", description="User to create a modmail channel for", required=True)):
+        category = discord.utils.get(interaction.guild.categories, name='COMMS')
+        channel = discord.utils.get(category.channels, topic=str(user.id))
+        if not channel:
+            channel = await interaction.guild.create_text_channel(str(user).replace("#", "-"),
+                                                                category=category, topic=str(user.id))
+        await interaction.response.send_message(f"DM Channel has been created at {channel.mention}")

--- a/commands/Modmail.py
+++ b/commands/Modmail.py
@@ -30,13 +30,6 @@ class Modmail(commands.Cog):
                 reaction, user = await self.bot.wait_for('reaction_add', check=check)
                 guild = mutual_guilds[int(str(reaction)[0])-1]
 
-            forum_channel = discord.utils.get(guild.channels, name='modmail', type=discord.ChannelType.forum)
-            if forum_channel is None:
-                forum_channel = await guild.create_forum_channel(name='modmail', topic="Modmail for DMs")
-            thread = discord.utils.get(forum_channel.threads, name=f"{message.author}")
-            if thread is None:
-                thread = await forum_channel.create_thread(name=f"{message.author}", auto_archive_duration=60, content="New DM received.")
-
             if functions.preferences.gpdb.get_pref("modmail_channel", guild.id): embed = discord.Embed(title="Message Received", description=f"This message will be sent to the mods of the {guild.name} server. Are you sure you want to send this?\nClick on the :white_check_mark: to confirm, and :x: to terminate this conversation", colour=discord.Colour.yellow())
             else:
                 embed = discord.Embed(title="Message Declined", description=f"{guild.name} has not yet setup modmail. Use /set_preferences to set it up", colour=discord.Colour.red())
@@ -51,6 +44,12 @@ class Modmail(commands.Cog):
                 return user == message.author and str(reaction.emoji) in ['✅', '❌']
             reaction, user = await self.bot.wait_for('reaction_add', check=check)
             if str(reaction.emoji) == '✅':
+                forum_channel = discord.utils.get(guild.channels, name='modmail', type=discord.ChannelType.forum)
+                if forum_channel is None:
+                    forum_channel = await guild.create_forum_channel(name='modmail', topic="Modmail for DMs")
+                thread = discord.utils.get(forum_channel.threads, name=f"{message.author}")
+                if thread is None:
+                    thread = await forum_channel.create_thread(name=f"{message.author}", auto_archive_duration=60, content="New DM received.")
                 embed = discord.Embed(title="Message Sent", description=f"Your message has been sent to the mods of the {guild.name} server.", colour=discord.Colour.green())
                 embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
                 await msg.edit(embed=embed)
@@ -68,7 +67,7 @@ class Modmail(commands.Cog):
                 await msg.delete()
 
         else:
-            modlog_channel_id = functions.preferences.gpdb.get_pref("modmail_channel", message.guild.id)
+            modmail_channel_id = functions.preferences.gpdb.get_pref("modmail_channel", message.guild.id)
             if str(message.channel.parent) == "modmail":
                 username, discriminator = message.channel.name.split('#')
                 user = discord.utils.find(lambda u: u.name == username and u.discriminator == discriminator, self.bot.users)
@@ -79,7 +78,7 @@ class Modmail(commands.Cog):
                                         description=f"DM Channel with {member} has been closed by the moderators of r/IGCSE, without notifying the user.", colour=discord.Colour.green())
                     embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
                     await message.channel.delete()
-                    await self.bot.get_channel(modlog_channel_id).send(embed=embed)
+                    await self.bot.get_channel(modmail_channel_id).send(embed=embed)
                     return
                 channel = await member.create_dm()  
                 if message.content == ".close":
@@ -88,7 +87,7 @@ class Modmail(commands.Cog):
                     embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
                     await channel.send(embed=embed)
                     await message.channel.delete()
-                    await self.bot.get_channel(modlog_channel_id).send(embed=embed)
+                    await self.bot.get_channel(modmail_channel_id).send(embed=embed)
                     return
                 embed = discord.Embed(title=f"Message from {message.guild.name} Moderators",
                                         description=message.clean_content, colour=discord.Colour.green())

--- a/commands/Reputation.py
+++ b/commands/Reputation.py
@@ -13,8 +13,11 @@ class Reputation(commands.Cog):
     @commands.Cog.listener()
     async def on_message(self, message):
         if message.author != self.bot.user:
-            if functions.preferences.gpdb.get_pref('rep_enabled', message.guild.id):
-                await functions.rep_funcs.repMessages(message)
+            try:
+                if functions.preferences.gpdb.get_pref('rep_enabled', message.guild.id):
+                    await functions.rep_funcs.repMessages(message)
+            except:
+                pass
 
     @discord.slash_command(description="View someone's current rep")
     async def rep(self, interaction: discord.Interaction,

--- a/commands/Reputation.py
+++ b/commands/Reputation.py
@@ -12,12 +12,11 @@ class Reputation(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message):
+        if not message.guild:
+            return
         if message.author != self.bot.user:
-            try:
-                if functions.preferences.gpdb.get_pref('rep_enabled', message.guild.id):
-                    await functions.rep_funcs.repMessages(message)
-            except:
-                pass
+            if functions.preferences.gpdb.get_pref('rep_enabled', message.guild.id):
+                await functions.rep_funcs.repMessages(message)
 
     @discord.slash_command(description="View someone's current rep")
     async def rep(self, interaction: discord.Interaction,

--- a/functions/preferences.py
+++ b/functions/preferences.py
@@ -10,7 +10,6 @@ class GuildPreferencesDB:
         self.pref = self.db["guild_preferences"]
 
     def set_pref(self, pref: str, pref_value, guild_id: int):
-        """ 'pref' can be 'modlog_channel' or 'rep_enabled'. """
         result = self.pref.update_one({"guild_id": guild_id}, {
                                       "$set": {pref: pref_value}}, upsert=True)
         return result

--- a/functions/utility.py
+++ b/functions/utility.py
@@ -2,7 +2,7 @@ import nextcord as discord
 import functions
 
 async def isModerator(member: discord.Member):
-    roles = [role.id for role in member.roles]
+    roles = [role.id for role in member.roles if role is not None]
     gpdb = functions.preferences.gpdb
     mod_roles = gpdb.get_pref('mod_roles', member.guild.id)
     if mod_roles and any(role in mod_roles for role in roles):

--- a/main.py
+++ b/main.py
@@ -2,6 +2,9 @@ import os
 from nextcord.ext import commands
 import nextcord as discord
 import functions
+from dotenv import load_dotenv
+
+load_dotenv()
 
 TOKEN = os.getenv("IGCSEBOT_TOKEN")
 
@@ -57,7 +60,7 @@ async def set_preferences(interaction: discord.Interaction,
                               description="Channel for modmail to take place.",
                               required=False)):
     gpdb = functions.preferences.gpdb
-    if not await functions.utility.isModerator(interaction.user):
+    if await functions.utility.isModerator(interaction.user):
         options = {
                 "modlog_channel": modlog_channel,
                 "rep_enabled": rep_enabled,

--- a/main.py
+++ b/main.py
@@ -2,9 +2,6 @@ import os
 from nextcord.ext import commands
 import nextcord as discord
 import functions
-from dotenv import load_dotenv
-
-load_dotenv()
 
 TOKEN = os.getenv("IGCSEBOT_TOKEN")
 

--- a/main.py
+++ b/main.py
@@ -50,22 +50,27 @@ async def set_preferences(interaction: discord.Interaction,
                           emote_channel: discord.abc.GuildChannel = discord.SlashOption(
                               name="emote_channel",
                               description="Channel for emote voting to take place.",
+                              required=False),
+                          modmail_channel: discord.abc.GuildChannel = discord.SlashOption(
+                              name="modmail_channel",
+                              description="Channel for modmail to take place.",
                               required=False)):
     gpdb = functions.preferences.gpdb
-    if not await functions.utility.isModerator(interaction.user):
-        await interaction.send("You are not authorized to perform this action", ephemeral=True)
-        return
-    await interaction.response.defer()
-    if modlog_channel:
-        gpdb.set_pref('modlog_channel', modlog_channel.id, interaction.guild.id)
-    if rep_enabled:
-        gpdb.set_pref('rep_enabled', rep_enabled, interaction.guild.id)
-    if suggestions_channel:
-        gpdb.set_pref("suggestions_channel", suggestions_channel.id, interaction.guild.id)
-    if warnlog_channel:
-        gpdb.set_pref("warnlog_channel", warnlog_channel.id, interaction.guild.id)
-    if emote_channel:
-        gpdb.set_pref("emote_channel", emote_channel.id, interaction.guild.id)
+    options = {
+            "modlog_channel": modlog_channel,
+            "rep_enabled": rep_enabled,
+            "suggestions_channel": suggestions_channel,
+            "warnlog_channel": warnlog_channel,
+            "emote_channel": emote_channel,
+            "modmail_channel": modmail_channel
+        }
+
+    for pref_name, option in options.items():
+        if option is not None:
+            if isinstance(option, discord.abc.GuildChannel):
+                gpdb.set_pref(pref_name, option.id, interaction.guild.id)
+            elif isinstance(option, bool):
+                gpdb.set_pref(pref_name, option, interaction.guild.id)
     await interaction.send("Done.")
 
 bot.run(dotenv_values(".env")["IGCSEBOT_TOKEN"])


### PR DESCRIPTION
Completed stuff relating to modmail. Brief overview:
 - If the user is in multiple servers with the bot, it identifies which server the user wants to send modmail to.
 - It uses threads to handle everything (Hence, can go up to 1000 DMs at a time)
 - Added a confirmation message so that users don't send it accidentally (They can terminate or proceed with the DM)
 - Doesn't allow modmail if the server has not setup the modmail channel (where the .close and .sclose messages go)
 - Allows you to do /create_modmail [user] which creates a thread where mods can then message the user directly through the bot